### PR TITLE
Avoid static

### DIFF
--- a/examples/nth.rs
+++ b/examples/nth.rs
@@ -11,7 +11,7 @@ pub fn main() {
     let options = SkimOptionsBuilder::default().query(Some("f")).build().unwrap();
     let item_reader = SkimItemReader::new(SkimItemReaderOption::default().nth("2").build());
 
-    let items = item_reader.of_bufread(Cursor::new(input));
+    let items = item_reader.of_bufread(Box::new(Cursor::new(input)));
     let selected_items = Skim::run_with(&options, Some(items))
         .map(|out| out.selected_items)
         .unwrap_or_else(Vec::new);

--- a/examples/option_builder.rs
+++ b/examples/option_builder.rs
@@ -13,7 +13,7 @@ pub fn main() {
     //==================================================
     // first run
     let input = "aaaaa\nbbbb\nccc";
-    let items = item_reader.of_bufread(Cursor::new(input));
+    let items = item_reader.of_bufread(Box::new(Cursor::new(input)));
     let selected_items = Skim::run_with(&options, Some(items))
         .map(|out| out.selected_items)
         .unwrap_or_else(Vec::new);
@@ -25,7 +25,7 @@ pub fn main() {
     //==================================================
     // second run
     let input = "11111\n22222\n333333333";
-    let items = item_reader.of_bufread(Cursor::new(input));
+    let items = item_reader.of_bufread(Box::new(Cursor::new(input)));
     let selected_items = Skim::run_with(&options, Some(items))
         .map(|out| out.selected_items)
         .unwrap_or_else(Vec::new);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -533,7 +533,7 @@ pub fn filter(
             .fuzzy_algorithm(options.algorithm)
             .exact_mode(options.exact)
             .build();
-        Box::new(AndOrEngineFactory::new(fuzzy_engine_factory))
+        Box::new(AndOrEngineFactory::new(Box::new(fuzzy_engine_factory)))
     };
 
     let engine = engine_factory.create_engine_with_case(query, options.case);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -318,7 +318,7 @@ fn real_main() -> Result<i32, std::io::Error> {
     //------------------------------------------------------------------------------
     // read from pipe or command
     let rx_item = if atty::isnt(atty::Stream::Stdin) {
-            let rx_item = cmd_collector.borrow().of_bufread(BufReader::with_capacity(READ_BUFFER_CAPACITY, std::io::stdin()));
+            let rx_item = cmd_collector.borrow().of_bufread(Box::new(BufReader::with_capacity(READ_BUFFER_CAPACITY, std::io::stdin())));
             Some(rx_item)
         } else {
          None

--- a/src/engine/factory.rs
+++ b/src/engine/factory.rs
@@ -136,10 +136,8 @@ pub struct AndOrEngineFactory {
 }
 
 impl AndOrEngineFactory {
-    pub fn new(factory: impl MatchEngineFactory + 'static) -> Self {
-        Self {
-            inner: Box::new(factory),
-        }
+    pub fn new(factory: Box<dyn MatchEngineFactory>) -> Self {
+        Self { inner: factory }
     }
 
     // we want to treat `\ ` as plain white space
@@ -260,7 +258,7 @@ mod test {
         assert_eq!(format!("{}", x), "(Exact|!(?i)^abc$)");
 
         let regex_factory = RegexEngineFactory::builder();
-        let and_or_factory = AndOrEngineFactory::new(exact_or_fuzzy);
+        let and_or_factory = AndOrEngineFactory::new(Box::new(exact_or_fuzzy));
 
         let x = and_or_factory.create_engine("'abc | def ^gh ij | kl mn");
         assert_eq!(

--- a/src/helper/ingest.rs
+++ b/src/helper/ingest.rs
@@ -26,7 +26,7 @@ pub struct BuildOptions<'a> {
 
 #[allow(unused_assignments)]
 pub fn ingest_loop(
-    mut source: impl BufRead + Send + 'static,
+    mut source: Box<dyn BufRead + Send>,
     line_ending: u8,
     tx_item: Sender<Arc<dyn SkimItem>>,
     opts: SendRawOrBuild,

--- a/src/helper/item_reader.rs
+++ b/src/helper/item_reader.rs
@@ -147,7 +147,7 @@ impl SkimItemReader {
 }
 
 impl SkimItemReader {
-    pub fn of_bufread(&self, source: impl BufRead + Send + 'static) -> SkimItemReceiver {
+    pub fn of_bufread(&self, source: Box<dyn BufRead + Send>) -> SkimItemReceiver {
         if self.option.is_simple() {
             self.raw_bufread(source)
         } else {
@@ -157,7 +157,7 @@ impl SkimItemReader {
     }
 
     /// helper: convert bufread into SkimItemReceiver
-    fn raw_bufread(&self, source: impl BufRead + Send + 'static) -> SkimItemReceiver {
+    fn raw_bufread(&self, source: Box<dyn BufRead + Send>) -> SkimItemReceiver {
         let (tx_item, rx_item): (SkimItemSender, SkimItemReceiver) = bounded(self.option.buf_size);
         let line_ending = self.option.line_ending;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,6 +282,7 @@ impl Skim {
     /// return:
     /// - None: on internal errors.
     /// - SkimOutput: the collected key, event, query, selected items, etc.
+    #[allow(unused_variables)]
     pub fn run_with(options: &SkimOptions, source: Option<SkimItemReceiver>) -> Option<SkimOutput> {
         let min_height = options
             .min_height
@@ -317,7 +318,7 @@ impl Skim {
 
         let tx_clone = tx.clone();
         let term_clone = term.clone();
-        let (_hangup_tx, hangup_rx): (Sender<Never>, Receiver<Never>) = bounded(0);
+        let (hangup_tx, hangup_rx): (Sender<Never>, Receiver<Never>) = bounded(0);
         let input_thread = thread::spawn(move || loop {
             if let Ok(key) = term_clone.poll_event() {
                 if key == TermEvent::User(()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::thread;
 
-use crossbeam::channel::{Receiver, Sender, bounded, TryRecvError};
+use crossbeam::channel::{bounded, Receiver, Sender, TryRecvError};
 use tuikit::prelude::{Event as TermEvent, *};
 
 pub use crate::ansi::AnsiString;
@@ -317,26 +317,22 @@ impl Skim {
 
         let tx_clone = tx.clone();
         let term_clone = term.clone();
-        let (hangup_tx, hangup_rx): (Sender<Never>, Receiver<Never>) = bounded(0);
-        let input_thread = thread::spawn(move || {
+        let (_hangup_tx, hangup_rx): (Sender<Never>, Receiver<Never>) = bounded(0);
+        let input_thread = thread::spawn(move || loop {
+            if let Ok(key) = term_clone.poll_event() {
+                if key == TermEvent::User(()) {
+                    break;
+                }
 
-            loop {
-                if let Ok(key) = term_clone.poll_event() {
-                    if key == TermEvent::User(()) {
-                        break;
-                    }
+                if is_channel_closed(&hangup_rx) {
+                    break;
+                }
 
-                    if is_channel_closed(&hangup_rx) {
-                        break
-                    }
-    
-                    let (key, action_chain) = input.translate_event(key);
-                    for event in action_chain.into_iter() {
-                        let _ = tx_clone.send((key, event));
-                    }
+                let (key, action_chain) = input.translate_event(key);
+                for event in action_chain.into_iter() {
+                    let _ = tx_clone.send((key, event));
                 }
             }
-
         });
 
         //------------------------------------------------------------------------------

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -76,7 +76,7 @@ impl Matcher {
 
     pub fn run<C>(&self, query: &str, disabled: bool, item_pool: Arc<ItemPool>, callback: C) -> MatcherControl
     where
-        C: Fn(Arc<SpinLock<Vec<MatchedItem>>>) + Send + 'static,
+        for<'a> C: Fn(Arc<SpinLock<Vec<MatchedItem>>>) + Send + 'a,
     {
         let matcher_engine = self.engine_factory.create_engine_with_case(query, self.case_matching);
         debug!("engine: {}", matcher_engine);

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -74,10 +74,13 @@ impl Matcher {
         self
     }
 
-    pub fn run<C>(&self, query: &str, disabled: bool, item_pool: Arc<ItemPool>, callback: C) -> MatcherControl
-    where
-        for<'a> C: Fn(Arc<SpinLock<Vec<MatchedItem>>>) + Send + 'a,
-    {
+    pub fn run(
+        &self,
+        query: &str,
+        disabled: bool,
+        item_pool: Arc<ItemPool>,
+        callback: Box<dyn Fn(Arc<SpinLock<Vec<MatchedItem>>>) + Send>,
+    ) -> MatcherControl {
         let matcher_engine = self.engine_factory.create_engine_with_case(query, self.case_matching);
         debug!("engine: {}", matcher_engine);
         let stopped = Arc::new(AtomicBool::new(false));

--- a/src/model.rs
+++ b/src/model.rs
@@ -130,12 +130,12 @@ impl Model {
             // use provided engine
             Matcher::builder(engine_factory.clone()).case(options.case).build()
         } else {
-            let fuzzy_engine_factory: Rc<dyn MatchEngineFactory> = Rc::new(AndOrEngineFactory::new(
+            let fuzzy_engine_factory: Rc<dyn MatchEngineFactory> = Rc::new(AndOrEngineFactory::new(Box::new(
                 ExactOrFuzzyEngineFactory::builder()
                     .exact_mode(options.exact)
                     .rank_builder(rank_builder.clone())
                     .build(),
-            ));
+            )));
             Matcher::builder(fuzzy_engine_factory).case(options.case).build()
         };
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -733,10 +733,15 @@ impl Model {
         };
 
         let tx = self.tx.clone();
-        let new_matcher_control = matcher.run(&query, self.disabled, self.item_pool.clone(), move |_| {
-            // notify refresh immediately
-            let _ = tx.send((Key::Null, Event::EvHeartBeat));
-        });
+        let new_matcher_control = matcher.run(
+            &query,
+            self.disabled,
+            self.item_pool.clone(),
+            Box::new(move |_| {
+                // notify refresh immediately
+                let _ = tx.send((Key::Null, Event::EvHeartBeat));
+            }),
+        );
 
         self.matcher_control.replace(new_matcher_control);
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -228,9 +228,12 @@ impl Model {
         if let Some(preview_cmd) = options.preview {
             let tx = Arc::new(SpinLock::new(self.tx.clone()));
             self.previewer = Some(
-                Previewer::new(Some(preview_cmd.to_string()), move || {
-                    let _ = tx.lock().send((Key::Null, Event::EvHeartBeat));
-                })
+                Previewer::new(
+                    Some(preview_cmd.to_string()),
+                    Box::new(move || {
+                        let _ = tx.lock().send((Key::Null, Event::EvHeartBeat));
+                    }),
+                )
                 .wrap(preview_wrap)
                 .delimiter(self.delimiter.clone())
                 .preview_offset(

--- a/src/previewer.rs
+++ b/src/previewer.rs
@@ -46,7 +46,7 @@ pub struct Previewer {
 impl Previewer {
     pub fn new<C>(preview_cmd: Option<String>, callback: C) -> Self
     where
-        C: Fn() + Send + Sync + 'static,
+        for<'a> C: Fn() + Send + Sync + 'a,
     {
         let content_lines = Arc::new(SpinLock::new(Vec::new()));
         let (tx_preview, rx_preview) = channel();
@@ -429,7 +429,7 @@ impl PreviewThread {
 
 fn run<C>(rx_preview: Receiver<PreviewEvent>, on_return: C)
 where
-    C: Fn(Vec<AnsiString>, PreviewPosition) + Send + Sync + 'static,
+    for<'a> C: Fn(Vec<AnsiString>, PreviewPosition) + Send + Sync + 'a,
 {
     let callback = Arc::new(on_return);
     let mut preview_thread: Option<PreviewThread> = None;


### PR DESCRIPTION
Avoid all static allocations so that we can deallocate skim related objects at the end of scopes